### PR TITLE
More reliable way to get latest d3 version from cdnjs

### DIFF
--- a/py_d3/py_d3.py
+++ b/py_d3/py_d3.py
@@ -115,7 +115,7 @@ d3.selectAll''' + str(self.max_id) + ''' = function(selection) {
                 res = urlopen(self._cdnjs_api_url).read()
                 if sys.version_info >= (3,0):
                     res = res.decode()
-                self._last_release = loads(res)["assets"][0]["version"]
+                self._last_release = loads(res)["version"]
                 return self._last_release
             except Exception:
                 pass


### PR DESCRIPTION
The version order of assets responded from cdnjs is _ascending_. The current implementation would always get the earliest version instead of the latest (which is `1.29.5` - a very outdated version - at the moment).

This change retrieves the latest version information directly from the `version` field instead o  assuming the assets' order.